### PR TITLE
collect_tfs.nf bug fixes

### DIFF
--- a/bin/merge_identical.py
+++ b/bin/merge_identical.py
@@ -13,6 +13,9 @@ args = parser.parse_args()
 
 df = pd.read_csv(args.input, sep="\t", index_col=0)
 
+# Remove additional metrics produced by STARE and keep only gene-TF affinities
+df = df.drop(columns=["NumPeaks", "AvgPeakDistance", "AvgPeakSize"])
+
 # Some column title are structured like "MEIS1(MA0498.1)" in this case we
 # want to remove the annotation in parenthesis and keep only the TF name
 # while calculating the mean of the expression values.

--- a/modules/local/ranking/collect_tfs.nf
+++ b/modules/local/ranking/collect_tfs.nf
@@ -28,6 +28,8 @@ process COLLECT_TFS {
 
     for path in paths:
         with open(path) as f:
+            # Skip header
+            next(f)
             for line in f:
                 tfgroup = line.strip().split("\\t")[0]
                 tfs = tfgroup.split("..")

--- a/modules/local/ranking/collect_tfs.nf
+++ b/modules/local/ranking/collect_tfs.nf
@@ -14,6 +14,10 @@ process COLLECT_TFS {
         path("tfs_sorted.txt"), emit: tfs
     
     script:
+    // Case that rankings contains only a single element
+    if (!(rankings instanceof List)) {
+        rankings = [rankings]
+    }
     """
     #!/usr/bin/env python3
 


### PR DESCRIPTION
### Current bugs:
- [x] collect_tfs.nf produces no output. With the current MM10 test data we produce only a single file in the rankings channel: `L1:L10_enhancers.ranking.tsv`.
Since the single file is not stored as a list in nextflow, the `rankings.name.join()` operation does not work and produces an empty string.
- [x] the final transcription factor list contains the elements _AvgPeakDistance_ and _AvgPeakSize_. This seems to come from the output of STARE (e.g. `enhancers_P6_TF_Gene_Affinities.txt`), which append three columns _NumPeaks_, _AvgPeakDistance_ and _AvgPeakSize_ to the matrix of gene-TF affinities.